### PR TITLE
Create noncoprimes.cpp

### DIFF
--- a/noncoprimes.cpp
+++ b/noncoprimes.cpp
@@ -1,0 +1,33 @@
+class Solution {
+    int lcmm(long long a,long long b){
+        return (int)((a*b)/(__gcd(a,b)));
+    }
+public:
+    vector<int> replaceNonCoprimes(vector<int>& nums) {
+        int n=nums.size();
+        stack<int> s;
+        for(int i=0;i<n;i++){
+            int x=nums[i];
+            if(s.empty()){s.push(nums[i]);}
+            else{
+                while(!s.empty()){
+                    if(__gcd(x,s.top())>1){
+                        
+                        x=lcmm(x,s.top());
+                        s.pop();
+                    }else{
+                        break;
+                    }
+                }
+                s.push(x);
+            }
+        }
+        vector<int> ans;
+        while(!s.empty()){
+            ans.push_back(s.top());
+            s.pop();
+        }
+        reverse(ans.begin(),ans.end());
+        return ans;
+    }
+};


### PR DESCRIPTION
You are given an array of integers nums. Perform the following steps:

Find any two adjacent numbers in nums that are non-coprime.
If no such numbers are found, stop the process.
Otherwise, delete the two numbers and replace them with their LCM (Least Common Multiple).
Repeat this process as long as you keep finding two adjacent non-coprime numbers.
Return the final modified array. It can be shown that replacing adjacent non-coprime numbers in any arbitrary order will lead to the same result.

The test cases are generated such that the values in the final array are less than or equal to 108.

Two values x and y are non-coprime if GCD(x, y) > 1 where GCD(x, y) is the Greatest Common Divisor of x and y.